### PR TITLE
docker-compose: add prometheus dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
 charon.yml
-<<<<<<< HEAD
 charon
-=======
-/prometheus/data
->>>>>>> 23cbe66 (address review comments)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,6 @@ services:
     networks: [cluster]
     volumes:
       - ./prometheus/prometheus.yaml:/etc/prometheus/prometheus.yaml
-      - ./prometheus/data:/prometheus/data
 
 networks:
   cluster:


### PR DESCRIPTION
Adds prometheus dashboard to http://localhost:9090

Category: feature
Ticket: #3 