### PR TITLE
add bootnode

### DIFF
--- a/bootnode/run.sh
+++ b/bootnode/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+# Support locally built charon binaries
+PATH="/charon:${PATH}"
+if [ "$(which charon)" = "/charon/charon" ]; then
+  echo "Running locally built charon binary"
+fi
+
+# Get container IP (https://stackoverflow.com/questions/13322485/how-to-get-the-primary-ip-address-of-the-local-machine-on-linux-and-os-x)
+BIND=$(ip route get 1 | awk '{print $NF;exit}')
+
+# Write a config file: charon.yml
+cat <<EOF > charon.yml
+data-dir: ${PWD}
+bootnode-http-address: ${BIND}:16001
+p2p-udp-address: ${BIND}:16004
+EOF
+
+# If p2p key doesn't exist yet, create it.
+if [ ! -f "p2pkey" ]; then
+  charon gen-p2pkey
+fi
+
+# Run bootnode
+exec charon bootnode

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,20 +22,21 @@ services:
     <<: *node-base
     working_dir: /charon/node1
     environment:
-      BOOTNODE: node0
       SIMNET_VMOCK: "false" # Uses Teku VC
 
   node2:
     <<: *node-base
     working_dir: /charon/node2
-    environment:
-      BOOTNODE: node0
 
   node3:
     <<: *node-base
     working_dir: /charon/node3
-    environment:
-      BOOTNODE: node0
+
+  bootnode:
+    <<: *node-base
+    image: ghcr.io/obolnetwork/charon/charon:latest # TODO(corver): Remove this once version above supports bootnode.
+    working_dir: /charon/bootnode
+    entrypoint: /charon/bootnode/run.sh
 
   vc0-lh:
     build: lighthouse

--- a/run.sh
+++ b/run.sh
@@ -23,19 +23,14 @@ if [ "${GENERATE}" = "true" ] && [ ! -f "/charon/manifest.json" ]; then
   rm /charon/node*/run.sh
 fi
 
-# If BOOTNODE env var present, resolve ENR via curl/wget
-if [ -n "${BOOTNODE}" ]; then
-  while ! ENR=$(wget -qO- "http://${BOOTNODE}:16001/enr" 2>/dev/null); do
-    echo "Waiting for http://${BOOTNODE}:16001/enr to become available..."
-    sleep 5
-  done
-fi
-
+while ! BOOTNODE_ENR=$(wget -qO- "http://bootnode:16001/enr" 2>/dev/null); do
+  echo "Waiting for http://bootnode:16001/enr to become available..."
+  sleep 5
+done
 
 # Get container IP (https://stackoverflow.com/questions/13322485/how-to-get-the-primary-ip-address-of-the-local-machine-on-linux-and-os-x)
 BIND=$(ip route get 1 | awk '{print $NF;exit}')
 NODE=$(basename "$(pwd)")
-
 
 # Write a config file: charon.yml
 cat <<EOF > charon.yml
@@ -43,7 +38,7 @@ data-dir: ${PWD}
 manifest-file: /charon/manifest.json
 monitoring-address: ${BIND}:16001
 validator-api-address: ${BIND}:16002
-p2p-bootnodes: ${ENR}
+p2p-bootnodes: ${BOOTNODE_ENR}
 p2p-tcp-address: ${BIND}:16003
 p2p-udp-address: ${BIND}:16004
 simnet-beacon-mock: true
@@ -51,7 +46,6 @@ simnet-validator-mock: ${SIMNET_VMOCK:-true}
 jaeger-address: jaeger:6831
 jaeger-service: ${NODE}
 EOF
-
 
 # Run charon
 exec charon run


### PR DESCRIPTION
Adds an explicit bootnode to the cluster. No need to use node0 as bootnode anymore.

category: feature
ticket: https://github.com/ObolNetwork/charon/issues/317