### PR TITLE
Add `vouch` as the third VC alongside `lighthouse` and `teku`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ split_keys/
 bootnode/charon-enr-private-key
 .idea/
 data/
+nethermind/nethermind_db/

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ The default cluster consists of six charon nodes using a mixture of validator cl
 - vc0: [Lighthouse](https://github.com/sigp/lighthouse)
 - vc1: [Teku](https://github.com/ConsenSys/teku)
 - vc2: [Vouch](https://github.com/attestantio/vouch)
-- vc3: [Teku](https://github.com/ConsenSys/teku)
-- vc4: [Lighthouse](https://github.com/sigp/lighthouse)
+- vc3: [Lighthouse](https://github.com/sigp/lighthouse)
+- vc4: [Teku](https://github.com/ConsenSys/teku)
 - vc5: [Vouch](https://github.com/attestantio/vouch)
 
 The intention is to support all validator clients, and work is underway to add support for lodestar to this repo, with nimbus and prysm support to follow in the future. Read more about our client support [here](https://github.com/ObolNetwork/charon#supported-consensus-layer-clients).

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ The default cluster consists of six charon nodes using a mixture of validator cl
 
 - vc0: [Lighthouse](https://github.com/sigp/lighthouse)
 - vc1: [Teku](https://github.com/ConsenSys/teku)
-- vc2: [Lighthouse](https://github.com/sigp/lighthouse)
+- vc2: [Vouch](https://github.com/attestantio/vouch)
 - vc3: [Teku](https://github.com/ConsenSys/teku)
 - vc4: [Lighthouse](https://github.com/sigp/lighthouse)
-- vc5: [Teku](https://github.com/ConsenSys/teku)
+- vc5: [Vouch](https://github.com/attestantio/vouch)
 
-The intention is to support all validator clients, and work is underway to add support for vouch and lodestar to this repo, with nimbus and prysm support to follow in future. Read more about our client support [here](https://github.com/ObolNetwork/charon#supported-consensus-layer-clients).
+The intention is to support all validator clients, and work is underway to add support for lodestar to this repo, with nimbus and prysm support to follow in the future. Read more about our client support [here](https://github.com/ObolNetwork/charon#supported-consensus-layer-clients).
 
 ## Create Distributed Validator Keys
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,53 +169,51 @@ services:
       - .charon/cluster/node1/validator_keys:/opt/charon/validator_keys
       - ./teku:/opt/charon/teku
 
-  vc2-lighthouse:
-    build: lighthouse
+  vc2-vouch:
+    build: vouch
     networks: [ cluster ]
     depends_on: [ node2 ]
-    env_file: .env
+    restart: on-failure
     environment:
       NODE: node2
-      ETH2_NETWORK: ${ETH2_NETWORK:-goerli}
     volumes:
-      - ./lighthouse:/opt/charon/lighthouse
-      - .charon/cluster/node2/validator_keys:/opt/charon/keys
+      - .charon/cluster/node2:/opt/charon/node
+      - ./vouch:/opt/charon/vouch
 
-  vc3-teku:
-    image: consensys/teku:${TEKU_VERSION:-22.9.1}
-    networks: [ cluster ]
-    depends_on: [ node3 ]
-    command: |
-      validator-client
-      --beacon-node-api-endpoint="http://node3:3600"
-      --config-file "/opt/charon/teku/teku-config.yaml"
-    volumes:
-      - .charon/cluster/node3/validator_keys:/opt/charon/validator_keys
-      - ./teku:/opt/charon/teku
-
-  vc4-lighthouse:
+  vc3-lighthouse:
     build: lighthouse
     networks: [ cluster ]
-    depends_on: [ node4 ]
+    depends_on: [ node3 ]
     env_file: .env
     environment:
-      NODE: node4
+      NODE: node3
       ETH2_NETWORK: ${ETH2_NETWORK:-goerli}
     volumes:
       - ./lighthouse:/opt/charon/lighthouse
-      - .charon/cluster/node4/validator_keys:/opt/charon/keys
+      - .charon/cluster/node3/validator_keys:/opt/charon/keys
 
-  vc5-teku:
+  vc4-teku:
     image: consensys/teku:${TEKU_VERSION:-22.9.1}
     networks: [ cluster ]
-    depends_on: [ node5 ]
+    depends_on: [ node4 ]
     command: |
       validator-client
-      --beacon-node-api-endpoint="http://node5:3600"
+      --beacon-node-api-endpoint="http://node4:3600"
       --config-file "/opt/charon/teku/teku-config.yaml"
     volumes:
-      - .charon/cluster/node5/validator_keys:/opt/charon/validator_keys
+      - .charon/cluster/node4/validator_keys:/opt/charon/validator_keys
       - ./teku:/opt/charon/teku
+
+  vc5-vouch:
+    build: vouch
+    networks: [ cluster ]
+    depends_on: [ node5 ]
+    restart: on-failure
+    environment:
+      NODE: node5
+    volumes:
+      - .charon/cluster/node5:/opt/charon/node
+      - ./vouch:/opt/charon/vouch
 
   #                        _ _             _
   #  _ __ ___   ___  _ __ (_) |_ ___  _ __(_)_ __   __ _

--- a/vouch/Dockerfile
+++ b/vouch/Dockerfile
@@ -1,0 +1,14 @@
+FROM wealdtech/ethdo:1.25.3 as ethdo
+
+FROM attestant/vouch:1.6.2
+
+COPY --from=ethdo /app/ethdo /app/ethdo
+
+RUN apt-get update && apt-get install -y curl jq wget
+
+ENV YQ_VERSION=v4.28.1
+ENV YQ_BINARY=yq_linux_amd64
+RUN wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY} -O /usr/bin/yq \
+    && chmod +x /usr/bin/yq
+
+ENTRYPOINT ["/opt/charon/vouch/run.sh"]

--- a/vouch/run.sh
+++ b/vouch/run.sh
@@ -29,7 +29,6 @@ function createVouchConfig() {
 
   # Set beacon node addresses.
   nodeAddr="http://${NODE}:3600"
-#  nodeAddr="192.168.1.10:5052"
   addr=${nodeAddr} yq -i '.beacon-node-address = strenv(addr)' ${vouchFile}
   addr=${nodeAddr} yq -i '.submitter.beacon-node-addresses[0] = strenv(addr)' ${vouchFile}
   addr=${nodeAddr} yq -i '.strategies.beaconblockproposal.beacon-node-addresses[0] = strenv(addr)' ${vouchFile}

--- a/vouch/run.sh
+++ b/vouch/run.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Running vouch VC is split into three steps:
+# 1. Converting keys into a format which vouch understands. This is what ethdo does.
+# 2. Creating configuration for vouch (vouch.yml).
+# 3. Actually running the vouch validator client.
+
+baseDir="/opt/charon/node/validator_keys/ethdo"
+vouchFile="/opt/charon/node/vouch.yml" # Copy vouch.yml to respective node folder.
+
+# Remove directory if it already exists.
+rm -r ${baseDir} || true
+
+# Create a fresh directory for ethdo keys.
+mkdir ${baseDir}
+
+# Create an ethdo wallet within the keys folder.
+wallet="validators"
+/app/ethdo --base-dir="${baseDir}" wallet create --wallet ${wallet}
+
+# Creates vouch configuration (vouch.yml) and updates it with the required data.
+function createVouchConfig() {
+  rm ${vouchFile}
+  cp /opt/charon/vouch/vouch.sample.yml ${vouchFile}
+
+  # Set accountmanager.
+  location=${baseDir} yq -i '.accountmanager.wallet.locations[0] = strenv(location)' ${vouchFile}
+  wallet=${wallet} yq -i '.accountmanager.wallet.accounts[0] = strenv(wallet)' ${vouchFile}
+
+  # Set beacon node addresses.
+  nodeAddr="http://${NODE}:3600"
+#  nodeAddr="192.168.1.10:5052"
+  addr=${nodeAddr} yq -i '.beacon-node-address = strenv(addr)' ${vouchFile}
+  addr=${nodeAddr} yq -i '.submitter.beacon-node-addresses[0] = strenv(addr)' ${vouchFile}
+  addr=${nodeAddr} yq -i '.strategies.beaconblockproposal.beacon-node-addresses[0] = strenv(addr)' ${vouchFile}
+  addr=${nodeAddr} yq -i '.strategies.attestationdata.beacon-node-addresses[0] = strenv(addr)' ${vouchFile}
+}
+
+createVouchConfig
+
+# Import keys into the ethdo wallet.
+account=0
+for f in /opt/charon/node/validator_keys/keystore-*.json; do
+  accountName="account-${account}"
+  echo "Importing key ${f} into ethdo wallet: ${wallet}/${accountName}"
+
+  PASSPHRASE=$(cat "${f//json/txt}")
+  /app/ethdo \
+    --base-dir="${baseDir}" account import \
+    --account="${wallet}"/"${accountName}" \
+    --keystore="$f" \
+    --passphrase="$PASSPHRASE" \
+    --keystore-passphrase="$PASSPHRASE"
+
+  # Save the passphrase to vouch.yml.
+  id=${account} pass=${PASSPHRASE} yq -i '.accountmanager.wallet.passphrases[env(id)] = strenv(pass)' ${vouchFile}
+
+  # Increment account.
+  # shellcheck disable=SC2003
+  account=$(expr "$account" + 1)
+done
+
+# Log wallet info.
+echo "Starting vouch validator client. Wallet info:"
+/app/ethdo \
+--base-dir=/opt/charon/keys/ethdo wallet info \
+--wallet="${wallet}" \
+--base-dir="${baseDir}" \
+--verbose
+
+# Now run vouch.
+exec /app/vouch --base-dir=/opt/charon/node

--- a/vouch/vouch.sample.yml
+++ b/vouch/vouch.sample.yml
@@ -1,0 +1,46 @@
+# Refer: https://github.com/attestantio/vouch/blob/master/docs
+beacon-node-address:
+
+accountmanager:
+  wallet:
+    locations:
+    accounts:
+    passphrases:
+
+# metrics is the module that logs metrics, in this case using prometheus. Note that vouch doesn't emit metrics if
+# the following block is not provided.
+metrics:
+  prometheus:
+    # listen-address is the address on which prometheus listens for metrics requests.
+    listen-address: 0.0.0.0:8081
+
+# submitter submits data to beacon nodes. If not present, the nodes in beacon-node-address above will be used.
+submitter:
+  # style can currently only be 'all'.
+  style: all
+  # beacon-node-addresses is the list of addresses to which submit. Submissions run in parallel.
+  beacon-node-addresses:
+    -
+
+# strategies provide advanced strategies for dealing with multiple beacon nodes.
+strategies:
+  beaconblockproposal:
+    # style can be 'best', which obtains blocks from all nodes and compares them, or 'first', which uses the first returned.
+    style: first
+    # beacon-node-addresses are the addresses of beacon nodes to use for this strategy.
+    beacon-node-addresses:
+      -
+
+  # The attestationdata strategy obtains attestation data from multiple sources.
+  attestationdata:
+    # style can be 'best', which obtains attestations from all nodes and selects the best, or 'first', which uses the first returned.
+    style: first
+    # beacon-node-addresses are the addresses of beacon nodes to use for this strategy.
+    beacon-node-addresses:
+      -
+
+feerecipient:
+  default-address: '0x0000000000000000000000000000000000000001'
+
+blockrelay:
+  fallback-fee-recipient: '0x0000000000000000000000000000000000000001'


### PR DESCRIPTION
Adds `vouch` as the third validator client alongside `lighthouse` and `teku`.

So, the cluster now consists of 6 `charon` nodes, 1 `nethermind` execution client, 1 `nimbus` beacon client, 2 `lighthouse` VCs, 2 `teku` VCs and 2 `vouch` VCs.

Ticket: https://github.com/ObolNetwork/charon-distributed-validator-cluster/issues/24