### PR TITLE
Upgrade to charon v0.11.0

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -34,13 +34,13 @@
 
 # Charon docker container image version, e.g. `latest` or `df6c9bf`.
 # See available tags https://hub.docker.com/r/obolnetwork/charon/tags.
-CHARON_VERSION=
+#CHARON_VERSION=
 
 # Connect to one or more beacon nodes. Use a comma separated list excluding spaces.
-CHARON_BEACON_NODE_ENDPOINTS=
+#CHARON_BEACON_NODE_ENDPOINTS=
 
 # Override the charon logging level; debug, info, warning, error.
-CHARON_LOG_LEVEL=
+#CHARON_LOG_LEVEL=
 
 # Override the charon logging format; console, logfmt, json. Grafana panels require logfmt.
 #CHARON_LOG_FORMAT=
@@ -52,19 +52,19 @@ CHARON_LOG_LEVEL=
 #CHARON_P2P_BOOTNODE_RELAY=
 
 # Define custom bootnodes. One or more ENRs or an http URL that return an ENR. Use a comma separated list excluding spaces.
-CHARON_P2P_BOOTNODES=
+#CHARON_P2P_BOOTNODES=
 
 # Advertise a custom external DNS hostname or IP address for UDP discv5 peer discovery.
 #CHARON_P2P_EXTERNAL_HOSTNAME=
 
 # Charon host exposed ports
-CHARON_P2P_TCP_ADDRESS=0.0.0.0:3610
-CHARON_P2P_UDP_ADDRESS=0.0.0.0:3630
-CHARON_VALIDATOR_API_ADDRESS=0.0.0.0:3600
-CHARON_MONITORING_ADDRESS=0.0.0.0:3620
+#CHARON_P2P_TCP_ADDRESS=0.0.0.0:3610
+#CHARON_P2P_UDP_ADDRESS=0.0.0.0:3630
+#CHARON_VALIDATOR_API_ADDRESS=0.0.0.0:3600
+#CHARON_MONITORING_ADDRESS=0.0.0.0:3620
 
 # Disable Jaeger tracing by setting an empty address.
-CHARON_JAEGER_ADDRESS=jaeger:6831
+#CHARON_JAEGER_ADDRESS=jaeger:6831
 
 # cluster-lock.json file location
 CHARON_LOCK_FILE=/opt/charon/.charon/cluster/cluster-lock.json

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ensure you have [docker](https://docs.docker.com/engine/install/) and [git](http
 
    ```sh
    # Create a testnet distributed validator cluster
-   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:v0.10.1 create cluster --withdrawal-address="0x000000000000000000000000000000000000dead" --nodes 6 --threshold 5
+   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:v0.11.0 create cluster --withdrawal-address="0x000000000000000000000000000000000000dead" --nodes 6 --threshold 5
    ```
 
 1. Start the cluster
@@ -87,7 +87,7 @@ The intention is to support all validator clients, and work is underway to add s
 Create some testnet private keys for a six node distributed validator cluster with the command:
 
 ```sh
-docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:v0.10.1 create cluster --withdrawal-address="0x000000000000000000000000000000000000dead" --nodes 6 --threshold 5
+docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:v0.11.0 create cluster --withdrawal-address="0x000000000000000000000000000000000000dead" --nodes 6 --threshold 5
 ```
 
 This command will create a subdirectory `.charon/cluster`. In it are six folders, one for each charon node created. Each folder contains partial private keys that together make up the distributed validator described in `.charon/cluster/cluster-lock.json`.
@@ -117,7 +117,7 @@ mkdir split_keys
 # E.g. keystore-0.json keystore-0.txt
 
 # Split these keystores into "n" (--nodes) key shares with "t" (--threshold) as threshold for a distributed validator
-docker run --rm  -v $(pwd):/opt/charon ghcr.io/obolnetwork/charon:v0.10.1 create cluster --split-existing-keys --split-keys-dir=/opt/charon/split_keys --threshold 3 --nodes 4
+docker run --rm  -v $(pwd):/opt/charon ghcr.io/obolnetwork/charon:v0.11.0 create cluster --split-existing-keys --split-keys-dir=/opt/charon/split_keys --threshold 3 --nodes 4
 
 # The above command will create 4 validator keys along with cluster-lock.json and deposit-data.json in ./.charon/cluster : 
 # .charon/cluster/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 x-node-base:
   # Pegged charon version (update this for each release).
   &node-base
-  image: obolnetwork/charon:${CHARON_VERSION:-v0.10.1}
+  image: obolnetwork/charon:${CHARON_VERSION:-v0.11.0}
   restart: on-failure
   environment:
     - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://nimbus:5052}


### PR DESCRIPTION
Bumps charon version to `v0.11.0`. Also, comment charon variables in `.env.sample`.