### PR TITLE
bump charon to `v0.17.0`

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -34,7 +34,7 @@
 
 ######### Charon Config #########
 
-# Charon docker container image version, e.g. `latest` or `v0.16.0`.
+# Charon docker container image version, e.g. `latest` or `v0.17.0`.
 # See available tags https://hub.docker.com/r/obolnetwork/charon/tags.
 #CHARON_VERSION=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   # | | | |  __/ |_| | | |  __/ |  | | | | | | | | | | (_| |
   # |_| |_|\___|\__|_| |_|\___|_|  |_| |_| |_|_|_| |_|\__,_|
   nethermind:
-    image: nethermind/nethermind:${NETHERMIND_VERSION:-1.19.2}
+    image: nethermind/nethermind:${NETHERMIND_VERSION:-1.20.1}
     restart: unless-stopped
     ports:
       - ${NETHERMIND_PORT_P2P:-30303}:30303/tcp # P2P TCP
@@ -180,7 +180,7 @@ services:
       - .charon/cluster/node0/validator_keys:/opt/charon/keys
 
   vc1-teku:
-    image: consensys/teku:${TEKU_VERSION:-23.5.0}
+    image: consensys/teku:${TEKU_VERSION:-23.8.0}
     networks: [ cluster ]
     depends_on: [ node1 ]
     restart: unless-stopped
@@ -217,7 +217,7 @@ services:
       - .charon/cluster/node3/validator_keys:/opt/charon/keys
 
   vc4-teku:
-    image: consensys/teku:${TEKU_VERSION:-23.5.0}
+    image: consensys/teku:${TEKU_VERSION:-23.8.0}
     networks: [ cluster ]
     depends_on: [ node4 ]
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
       - .charon/cluster/node0/validator_keys:/opt/charon/keys
 
   vc1-teku:
-    image: consensys/teku:${TEKU_VERSION:-23.8.0}
+    image: consensys/teku:${TEKU_VERSION:-23.5.0}
     networks: [ cluster ]
     depends_on: [ node1 ]
     restart: unless-stopped
@@ -217,7 +217,7 @@ services:
       - .charon/cluster/node3/validator_keys:/opt/charon/keys
 
   vc4-teku:
-    image: consensys/teku:${TEKU_VERSION:-23.8.0}
+    image: consensys/teku:${TEKU_VERSION:-23.5.0}
     networks: [ cluster ]
     depends_on: [ node4 ]
     restart: unless-stopped

--- a/nimbus/Dockerfile
+++ b/nimbus/Dockerfile
@@ -1,6 +1,6 @@
-FROM statusim/nimbus-eth2:multiarch-v23.5.1 as nimbusbn
+FROM statusim/nimbus-eth2:multiarch-v23.8.0 as nimbusbn
 
-FROM statusim/nimbus-validator-client:multiarch-v23.5.1
+FROM statusim/nimbus-validator-client:multiarch-v23.8.0
 
 COPY --from=nimbusbn /home/user/nimbus_beacon_node /home/user/nimbus_beacon_node
 


### PR DESCRIPTION
Bump `charon` to latest release `v0.17.0`. Also, bump `nethermind`, `teku` & `nimbus` docker images.