### PR TITLE
dencun on holesky and sepolia

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,7 +6,7 @@
 
 ######### Nethermind Config #########
 
-# Nethermind docker container image version, e.g. `latest` or `1.14.3`.
+# Nethermind docker container image version, e.g. `latest` or `1.25.3`.
 # See available tags https://hub.docker.com/r/nethermind/nethermind/tags
 #NETHERMIND_VERSION=
 
@@ -25,7 +25,7 @@
 
 ######### Teku Config #########
 
-# Teku validator client docker container image version, e.g. `latest` or `22.3.1`.
+# Teku validator client docker container image version, e.g. `latest` or `24.1.1`.
 # See available tags https://hub.docker.com/r/consensys/teku/tags
 #TEKU_VERSION=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   # | | | |  __/ |_| | | |  __/ |  | | | | | | | | | | (_| |
   # |_| |_|\___|\__|_| |_|\___|_|  |_| |_| |_|_|_| |_|\__,_|
   nethermind:
-    image: nethermind/nethermind:${NETHERMIND_VERSION:-1.25.0}
+    image: nethermind/nethermind:${NETHERMIND_VERSION:-1.25.3}
     restart: unless-stopped
     ports:
       - ${NETHERMIND_PORT_P2P:-30303}:30303/tcp # P2P TCP
@@ -62,7 +62,7 @@ services:
   #      |___/
 
   lighthouse:
-    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.6.0-rc.0}
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.6.0}
     ports:
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/tcp # P2P TCP
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/udp # P2P UDP
@@ -167,7 +167,7 @@ services:
   #  \ V / (_| | | | (_| | (_| | || (_) | |  \__ \
   #   \_/ \__,_|_|_|\__,_|\__,_|\__\___/|_|  |___/
   vc0-lighthouse:
-    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.6.0-rc.0}
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.6.0}
     entrypoint: /opt/lighthouse/run.sh
     networks: [ cluster ]
     depends_on: [ node0 ]
@@ -180,7 +180,7 @@ services:
       - .charon/cluster/node0/validator_keys:/opt/charon/keys
 
   vc1-teku:
-    image: consensys/teku:${TEKU_VERSION:-24.1.0}
+    image: consensys/teku:${TEKU_VERSION:-24.1.1}
     networks: [ cluster ]
     depends_on: [ node1 ]
     restart: unless-stopped
@@ -205,7 +205,7 @@ services:
       - ./nimbus:/home/user/data
 
   vc3-lighthouse:
-    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.6.0-rc.0}
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.6.0}
     entrypoint: /opt/lighthouse/run.sh
     networks: [ cluster ]
     depends_on: [ node3 ]
@@ -218,7 +218,7 @@ services:
       - .charon/cluster/node3/validator_keys:/opt/charon/keys
 
   vc4-teku:
-    image: consensys/teku:${TEKU_VERSION:-24.1.0}
+    image: consensys/teku:${TEKU_VERSION:-24.1.1}
     networks: [ cluster ]
     depends_on: [ node4 ]
     restart: unless-stopped

--- a/nimbus/Dockerfile
+++ b/nimbus/Dockerfile
@@ -1,4 +1,4 @@
-FROM statusim/nimbus-eth2:multiarch-v24.1.1 as nimbusbn
+FROM statusim/nimbus-eth2:multiarch-v24.1.2 as nimbusbn
 
 FROM statusim/nimbus-validator-client:multiarch-v24.1.1
 


### PR DESCRIPTION
Update clients to support upcoming dencun fork on sepolia and holesky testnets.

https://blog.ethereum.org/2024/01/24/sepolia-holesky-dencun

ticket: #135 